### PR TITLE
Added MongoDB plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # munin-plugins
 A collection of plugins for Munin used @Etalab.
 
+- [MongoDB](mongo/)
+
 ## udata-worker-status
 
 Plugin to graph the number of Celery tasks by type currently in the Celery queue. Relies on the `udata worker status` command of uData.
+

--- a/mongo/README.md
+++ b/mongo/README.md
@@ -1,0 +1,61 @@
+# Munin plugins for MongoDB
+
+Monitor MongoDB using Munin
+
+## Requirements
+
+* MongoDB 3+
+* Python 2.7+
+* Pymongo
+
+## Common parameters
+
+These plugins rely on environment variables for configuration.
+
+They share the `MONGO_URI` parameter which default to localhost if not provided.
+
+If you want to graph an instance which is not available on `mongodb://localhost:27017`, you will need to provide this parameter into your plugin's configuration.
+
+**Ex:** For a MongoDB instance running on `any.host:27018`, a `/etc/munin/plugin-conf.d/mongo` file can contain:
+
+```ini
+[mongo_*]
+env.MONGO_URI mongodb://any.host:27017
+```
+
+## Plugins
+
+### `mongo_conn`
+
+Display the number of current connections
+
+### `mongo_db_`
+
+A multigraph plugin providing the following metrics for a given database:
+- average object size
+- per collection data size
+- per collection document count
+- per collection index size
+- per collection storage size
+
+#### Parameters
+
+* `MONGO_IGNORE_COLLECTION`: a comma separated list of collections to ignore
+
+#### Usage
+
+This is a wildcard plugin expecting the database name as filename parameter.
+
+**Ex:** to displau metrics about `mine` collection, just name it `mongo_db_mine`
+
+```shell
+ln -s /path/to/repository/mongo/mongo_db_ /etc/munin/plugins/mongo_db_mine
+```
+
+### `mongo_mem`
+
+Graph MongoDB mapped, virtual and resident memory usage
+
+### `mongo_ops`
+
+Graph the number of operations by second

--- a/mongo/mongo_conn
+++ b/mongo/mongo_conn
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+from __future__ import print_function
+
+import sys
+import os
+import pymongo
+
+# Fetch config
+URI = os.environ.get('MONGO_URI', 'localhost')
+NAME = 'connections'
+
+
+def get_status(key):
+    client = pymongo.MongoClient(URI)
+    status = client.admin.command('serverStatus', workingSet=True)
+    return status[key]
+
+
+def get_data():
+    print('{0}.value {1}'.format(NAME, get_status('connections')['current']))
+
+
+def get_config():
+    print('graph_title MongoDB current connections')
+    print('graph_args --base 1000 -l 0')
+    print('graph_vlabel connections')
+    print('graph_category MongoDB')
+    print('{0}.label {0}'.format(NAME))
+
+
+if __name__ == '__main__':
+    if len(sys.argv) > 1 and sys.argv[1] == 'config':
+        get_config()
+    else:
+        get_data()

--- a/mongo/mongo_db_
+++ b/mongo/mongo_db_
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+# from __future__ import print_function
+
+import os
+import pymongo
+import re
+import sys
+
+# Config
+URI = os.environ.get('MONGO_URI', 'localhost')
+IGNORED = os.environ.get('MONGO_IGNORE_COLLECTION', '').split(',')
+GRAPHS = {
+    'collcount': {
+        'index': 'count',
+        'title': 'per collection document count',
+        'yaxis': 'documents',
+        'base': '1000',
+        'scale': '--logarithmic -l1',
+        'category': 'db',
+    },
+    'collsize': {
+        'index': 'size',
+        'title': 'per collection data size',
+        'yaxis': 'Byte',
+        'base': '1024',
+        'scale': '--logarithmic -l1 --units=si',
+        'category': 'db',
+    },
+    'avgsize': {
+        'index': 'avgObjSize',
+        'title': 'average object size',
+        'yaxis': 'Byte',
+        'base': '1024',
+        'scale': '--logarithmic --units=si',
+        'category': 'db',
+    },
+    'storage': {
+        'index': 'storageSize',
+        'title': 'per collection storage size',
+        'yaxis': 'Byte',
+        'base': '1024',
+        'scale': '--logarithmic -l1 --units=si',
+        'category': 'db',
+    },
+    'indexsize': {
+        'index': 'totalIndexSize',
+        'title': 'per collection index size',
+        'yaxis': 'Byte',
+        'base': '1024',
+        'scale': '--logarithmic -l 1 --units=si',
+        'category': 'db',
+    },
+}
+RE_WILDCARD = re.compile(r'^mongo_db_([\w\d-]+)$')
+
+
+def get_db(name):
+    client = pymongo.MongoClient(URI)
+    return client[name]
+
+
+def get_data(dbname):
+    db = get_db(dbname)
+    for graph, specs in GRAPHS.items():
+        # for db in databases():
+        print('multigraph {graph}_{db.name}'.format(graph=graph, db=db))
+        for coll in db.collection_names():
+            serie = '{graph}_{db.name}_{coll}'.format(graph=graph, db=db, coll=coll)
+            collstats = db.command('collstats', coll)
+            value = collstats.get(specs['index'], 0)
+            print('{serie}.value {value}'.format(**locals()))
+
+
+def get_config(dbname):
+    db = get_db(dbname)
+    for graph, specs in GRAPHS.items():
+        print('multigraph {graph}_{db.name}'.format(graph=graph, db=db))
+        print('graph_title {db.name} - {title}'.format(db=db, **specs))
+        print('graph_args --base {base} {scale}'.format(**specs))
+        print('graph_vlabel {yaxis}'.format(**specs))
+        print('graph_category MongoDB')
+        for coll in db.collection_names():
+            serie = '{graph}_{db.name}_{coll}'.format(graph=graph, db=db, coll=coll)
+            print('{serie}.label {coll}'.format(serie=serie, coll=coll))
+            print('{}.min 0'.format(serie))
+            print('{}.draw LINE1'.format(serie))
+
+
+def suggest():
+    print('keys')
+    for key in GRAPHS.keys():
+        print(key)
+
+
+if __name__ == '__main__':
+    filename = os.path.basename(sys.argv[0])
+    m = RE_WILDCARD.match(filename)
+    if not m:
+        print('This wildcard plugin must by symlinked with '
+              'the pattern mongo_db_<name>')
+        sys.exit(-1)
+    dbname = m.group(1)
+
+    if len(sys.argv) < 2:
+        get_data(dbname)
+    elif sys.argv[1] == 'config':
+        get_config(dbname)
+    elif sys.argv[1] == 'autoconf':
+        print('yes')
+    elif sys.argv[1] == 'suggest':
+        suggest()
+    else:
+        print('invalid argument')
+        sys.exit(-11)

--- a/mongo/mongo_docs
+++ b/mongo/mongo_docs
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+from __future__ import print_function
+
+import sys
+import os
+import pymongo
+
+# Config
+URI = os.environ.get('MONGO_URI', 'localhost')
+NAME = 'documents'
+
+
+def get_status(key):
+    client = pymongo.MongoClient(URI)
+    status = client.admin.command('serverStatus', workingSet=True)
+    return status[key]
+
+
+def get_data():
+    for k, v in get_status('metrics')['document'].items():
+        print('{0}.value {1}'.format(k, v))
+
+
+def get_config():
+    print('graph_title MongoDB documents')
+    print('graph_args --base 1000 -l 0')
+    print('graph_vlabel documents')
+    print('graph_category MongoDB')
+    for key in get_status('metrics')['document']:
+        print('{0}.label {0}'.format(key))
+        print('{}.min 0'.format(key))
+        print('{}.type COUNTER'.format(key))
+        print('{}.max 500000'.format(key))
+        print('{}.draw LINE1'.format(key))
+
+
+if __name__ == '__main__':
+    if len(sys.argv) > 1 and sys.argv[1] == 'config':
+        get_config()
+    else:
+        get_data()

--- a/mongo/mongo_mem
+++ b/mongo/mongo_mem
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+from __future__ import print_function
+
+import sys
+import os
+import pymongo
+
+# Config
+URI = os.environ.get('MONGO_URI', 'localhost')
+
+
+def get_status(key):
+    client = pymongo.MongoClient(URI)
+    status = client.admin.command('serverStatus', workingSet=True)
+    return status[key]
+
+
+def ok(s):
+    return s in ('resident', 'virtual', 'mapped')
+
+
+def get_data():
+    for k, v in get_status('mem').items():
+        if ok(k):
+            print('{0}.value {1}'.format(k, v * 1024 * 1024))
+
+
+def get_config():
+    print('graph_title MongoDB memory usage')
+    print('graph_args --base 1024 -l 0 --vertical-label Bytes')
+    print('graph_category MongoDB')
+
+    for key in get_status('mem'):
+        if ok(key):
+            print('{0}.label {0}'.format(key))
+            print('{}.draw LINE1'.format(key))
+
+
+if __name__ == '__main__':
+    if len(sys.argv) > 1 and sys.argv[1] == 'config':
+        get_config()
+    else:
+        get_data()

--- a/mongo/mongo_ops
+++ b/mongo/mongo_ops
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+from __future__ import print_function
+
+import sys
+import os
+import pymongo
+
+# Config
+URI = os.environ.get('MONGO_URI', 'localhost')
+
+
+def get_status(key):
+    client = pymongo.MongoClient(URI)
+    status = client.admin.command('serverStatus', workingSet=True)
+    return status[key]
+
+
+def get_data():
+    for k, v in get_status('opcounters').items():
+        print('{0}.value {1}'.format(k, v))
+
+
+def get_config():
+    print('graph_title MongoDB ops')
+    print('graph_args --base 1000 -l 0')
+    print('graph_vlabel ops / ${graph_period}')
+    print('graph_category MongoDB')
+    print('graph_total total')
+
+    for key in get_status('opcounters'):
+        print('{0}.label {0}'.format(key))
+        print('{}.min 0'.format(key))
+        print('{}.type COUNTER'.format(key))
+        print('{}.max 500000'.format(key))
+        print('{}.draw LINE1'.format(key))
+
+
+if __name__ == '__main__':
+    if len(sys.argv) > 1 and sys.argv[1] == 'config':
+        get_config()
+    else:
+        get_data()


### PR DESCRIPTION
This PR adds some MongoDB plugins


## Requirements

* MongoDB 3+
* Python 2.7+
* Pymongo

## Common parameters

These plugins rely on environment variables for configuration.

They share the `MONGO_URI` parameter which default to localhost if not provided.

If you want to graph an instance which is not available on `mongodb://localhost:27017`, you will need to provide this parameter into your plugin's configuration.

**Ex:** For a MongoDB instance running on `any.host:27018`, a `/etc/munin/plugin-conf.d/mongo` file can contain:

```ini
[mongo_*]
env.MONGO_URI mongodb://any.host:27017
```

## Plugins

### `mongo_conn`

Display the number of current connections

### `mongo_db_`

A multigraph plugin providing the following metrics for a given database:
- average object size
- per collection data size
- per collection document count
- per collection index size
- per collection storage size

#### Parameters

* `MONGO_IGNORE_COLLECTION`: a comma separated list of collections to ignore

#### Usage

This is a wildcard plugin expecting the database name as filename parameter.

**Ex:** to displau metrics about `mine` collection, just name it `mongo_db_mine`

```shell
ln -s /path/to/repository/mongo/mongo_db_ /etc/munin/plugins/mongo_db_mine
```

### `mongo_mem`

Graph MongoDB mapped, virtual and resident memory usage

### `mongo_ops`

Graph the number of operations by second
