### PR TITLE
Added udata-worker-status plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ A collection of plugins for Munin used @Etalab.
 
 - [MongoDB](mongo/)
 - [Redis](redis/)
+- [udata](udata/)
 
 ## udata-worker-status
 

--- a/udata/README.md
+++ b/udata/README.md
@@ -1,0 +1,39 @@
+# Munin plugins for udata
+
+Monitor udata using Munin
+
+## Requirements
+
+* udata
+
+## Common parameters
+
+These plugins rely on environment variables for configuration:
+- `UDATA_BIN`: the full path to the udata binary.
+- `UDATA_SETTINGS`: the full path to the `udata.cfg` settings file.
+
+**Ex:** For a udata instance installed in `/srv/udata`, a `/etc/munin/plugin-conf.d/udata` file can contain:
+
+```ini
+[udata*]
+env.UDATA_BIN /srv/udata/bin/udata
+env.UDATA_SETTINGS /srv/udata/udata.cfg
+```
+
+## Plugins
+
+### `udata-worker-status_`
+
+Graphs the current number of Celery tasks by type in a given Celery queue.
+
+Relies on the `udata worker status` command of udata.
+
+#### Usage
+
+This is a wildcard plugin expecting the queue name as filename parameter.
+
+**Ex:** to display metrics about `default` queue, just name it `udata-worker-status_default`
+
+```shell
+ln -s /path/to/repository/udata/udata-worker-status_ /etc/munin/plugins/udata-worker-status_default
+```

--- a/udata/udata-worker-status_
+++ b/udata/udata-worker-status_
@@ -1,0 +1,17 @@
+#!/bin/bash
+##
+# Monitor udata worker status for a given queue
+#
+# The queue name is expected as woldcard parameter (ie. udata-worker-status_QUEUE)
+# The udata config is expected as environment variable (ie. in /etc/munin/plugin-conf.d):
+#   UDATA_BIN=/srv/udata/bin/udata
+#   UDATA_SETTINGS=/srv/udata/udata.cfg
+##
+
+QUEUE=`echo $0 | cut -d _ -f 2`
+
+if [ "$1" = "config" ]; then
+    $UDATA_BIN worker status --munin-config -q $QUEUE
+else
+    $UDATA_BIN worker status --munin -q $QUEUE
+fi


### PR DESCRIPTION
This PR duplicate the root `udata-worker-status` plugins to `udata/udata-worker-status_` to keep the `app/plugin` structure.

This plugin has been modified to:
- make use of wildcard plugins filename parameter to extract the queue name (ie. avoid duplicating code and simply link it to `udata-worker-status_QUEUE` for each queue
- make use of the standard munin way of using environment variables (avoid hardcoding udata binary path and `udata.cfg` path, just put 

As a result, there is only one generic configurable plugin file.

**Ex:**
Given udata binary is located in `/path/to/udata` and `udata.cfg` in `/path/to/udata.cfg`, simply put in `/etc/munin/plugin-conf.d/udata`:
```ini
[udata*]
env.UDATA_BIN /path/to/udata
env.UDATA_SETTINGS /path/to/udata.cfg
```

To monitor the `low,`, `default` and `high` queues, given this repository is located in `/path/to/repository`, create the following symlinks:
- `/etc/munin/plugins/udata-worker-status_low` ⇨ `/path/to/repository/udata/udata-worker-status_`
- `/etc/munin/plugins/udata-worker-status_default` ⇨ `/path/to/repository/udata/udata-worker-status_`
- `/etc/munin/plugins/udata-worker-status_high` ⇨ `/path/to/repository/udata/udata-worker-status_`

The old `udata-worker-status` is left untouched until servers using it migrate to the new one